### PR TITLE
Added work around to changes in XCode 5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ At this point you should install peewee as well:
 $ easy_install peewee
 ```
 Psutil is needed for gathering system usage/performance stats on the worker. Ideally psutil is needed only on the workers.
+
 For Linux :
 
 ```


### PR DESCRIPTION
Since XCode 5.1, unknown arguments in command line installations, are treated as errors, therefor fails the installation.

Adding the ARCHFLAGS changes errors to warnings.
