### PR TITLE
Customized Worker storage path for HPPC needs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,11 @@ venv/
 *.ropeproject*
 config.py
 /flamenco/config.py
+/flamenco/server/application/config.py
+/flamenco/manager/application/config.py
+/flamenco/dashboard/application/config.py
+/flamenco/worker/application/config.py
+
 /flamenco/server/render
 /flamenco/manager/application/static/storage/*
 /flamenco/server/application/static/storage/*

--- a/README.md
+++ b/README.md
@@ -75,14 +75,17 @@ npm install
 grunt
 ```
 
-#### Debian Linux
-On linux you can install NodeJS using the package manager.
+#### Debian Linux Wheezy
+
 ```
-aptitude install python3-pip libmysqlclient-dev build-essential python-dev libjpeg-dev
+aptitude install python3-pip libmysqlclient-dev build-essential python-dev libjpeg8 libjpeg8-dev libfreetype6 libfreetype6-dev zlib1g-dev
+
+# install blender BAM using pip3
 pip3 install blender-bam
 
 # dashboard dependencies
 cd flamenco/dashboard
+# On linux you can install NodeJS using the package manager.
 echo "deb http://ftp.us.debian.org/debian wheezy-backports main" >> /etc/apt/sources.list
 apt-get update
 apt-get install nodejs nodejs-legacy curl

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ aptitude install python3-pip libmysqlclient-dev build-essential python-dev libjp
 pip3 install blender-bam
 
 # install python deps (remember to `source bin/activate` first!)
-install -r $FLAMENCODIR/requirements.txt
+pip install -r $FLAMENCODIR/requirements.txt
 
 # dashboard dependencies
 cd flamenco/dashboard

--- a/README.md
+++ b/README.md
@@ -85,8 +85,7 @@ sudo pip install virtualenv
 sudo pip3 install blender-bam
 
 # install python deps (remember to `source bin/activate` first!)
-# you have to sudo because of mako-render script, it installs to /usr/local/bin as many other dependencies stuffs
-sudo pip install -r $FLAMENCODIR/requirements.txt
+pip install -r $FLAMENCODIR/requirements.txt
 
 # dashboard dependencies
 cd flamenco/dashboard

--- a/README.md
+++ b/README.md
@@ -75,16 +75,18 @@ npm install
 grunt
 ```
 
-#### Debian Linux Wheezy
+#### Debian Linux Wheezy and Ubuntu 14.04
 
 ```
-aptitude install python3-pip libmysqlclient-dev build-essential python-dev libjpeg8 libjpeg8-dev libfreetype6 libfreetype6-dev zlib1g-dev
+sudo aptitude install python3-pip libmysqlclient-dev build-essential python-dev libjpeg8 libjpeg8-dev libfreetype6 libfreetype6-dev zlib1g-dev python-pip
 
+sudo pip install virtualenv
 # install blender BAM using pip3
-pip3 install blender-bam
+sudo pip3 install blender-bam
 
 # install python deps (remember to `source bin/activate` first!)
-pip install -r $FLAMENCODIR/requirements.txt
+# you have to sudo because of mako-render script, it installs to /usr/local/bin as many other dependencies stuffs
+sudo pip install -r $FLAMENCODIR/requirements.txt
 
 # dashboard dependencies
 cd flamenco/dashboard

--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ aptitude install python3-pip libmysqlclient-dev build-essential python-dev libjp
 # install blender BAM using pip3
 pip3 install blender-bam
 
+# install python deps (remember to `source bin/activate` first!)
+install -r $FLAMENCODIR/requirements.txt
+
 # dashboard dependencies
 cd flamenco/dashboard
 # On linux you can install NodeJS using the package manager.

--- a/README.md
+++ b/README.md
@@ -90,20 +90,23 @@ sudo pip install -r $FLAMENCODIR/requirements.txt
 
 # dashboard dependencies
 cd flamenco/dashboard
+
+# this is needed only on wheezy distribution
+sudo echo "deb http://ftp.us.debian.org/debian wheezy-backports main" >> /etc/apt/sources.list
+sudo apt-get update
+
 # On linux you can install NodeJS using the package manager.
-echo "deb http://ftp.us.debian.org/debian wheezy-backports main" >> /etc/apt/sources.list
-apt-get update
-apt-get install nodejs nodejs-legacy curl
-curl -L --insecure https://www.npmjs.org/install.sh | bash
-npm install -g grunt-cli
-apt-get install ruby
-gem install sass
-npm install
+sudo apt-get install nodejs nodejs-legacy curl
+sudo curl -L --insecure https://www.npmjs.org/install.sh | bash
+sudo npm install -g grunt-cli
+sudo apt-get install ruby
+sudo gem install sass
+sudo npm install
 grunt
 ```
 
 ## Running Flamenco
-It's pretty simple. Move into each folder (dashboard, server, manager or worker)
+It's pretty simple. Move into each folder ( server, manager, dashboard, worker)
 and run:
 
 ```

--- a/flamenco/manager/application/config.py.example
+++ b/flamenco/manager/application/config.py.example
@@ -24,5 +24,8 @@ class Config(object):
     SETTINGS_PATH_WIN = ""
     TMP_FOLDER = tempfile.gettempdir()
     THUMBNAIL_EXTENSIONS = set(['png'])
+    
+    # Don't change this variable until the worker's code will have costant declaration of this path
+    # see controllers.py line 243 to understand
     MANAGER_STORAGE = '{0}/static/storage'.format(
         os.path.join(os.path.dirname(__file__)))

--- a/flamenco/manager/application/task_compilers/tiled_blender_render_simple_mix.py
+++ b/flamenco/manager/application/task_compilers/tiled_blender_render_simple_mix.py
@@ -38,7 +38,7 @@ class task_compiler():
             logging.warning("Render settings path not set!")
             return None"""
 
-        tiles_path = "tiled_{{0}}_{0:04d}.exr".format(settings['frame_start'])
+        tiles_path = "tiled_{{0}}_{0:04d}.exr".format(int(settings['frame_start']))
 
         # render_settings = os.path.join(
         #     setting_render_settings,

--- a/flamenco/server/application/job_compilers/tiled_blender_render.py
+++ b/flamenco/server/application/job_compilers/tiled_blender_render.py
@@ -25,8 +25,8 @@ class job_compiler():
         task_settings['output_path_osx'] = os.path.join(project.render_path_osx, str(job.id))
         task_settings['priority'] = job.priority
 
-        task_settings['frame_start']=job_settings['frame_start']
-        task_settings['frame_end']=job_settings['frame_start']
+        task_settings['frame_start']=job_settings['frames'].split('-')[0]
+        task_settings['frame_end']=job_settings['frames'].split('-')[0]
 
         tiles = 4
         task_settings['tiles']=tiles

--- a/flamenco/worker/application/__init__.py
+++ b/flamenco/worker/application/__init__.py
@@ -24,6 +24,8 @@ try:
         FLAMENCO_MANAGER = config.Config.FLAMENCO_MANAGER,
         TMP_FOLDER = config.Config.TMP_FOLDER,
         PORT = config.Config.PORT,
+	HOSTNAME = config.Config.HOSTNAME,
+        WORKER_STORAGE_DIR = config.Config.WORKER_STORAGE_DIR,
     )
 except ImportError:
     # If we don't find the config.py we use the following defaults

--- a/flamenco/worker/application/__init__.py
+++ b/flamenco/worker/application/__init__.py
@@ -29,13 +29,18 @@ try:
         BLENDER_PATH = config.Config.BLENDER_PATH,
 
     )
-except ImportError:
+except ImportError as e:
+    print e   
+    import socket
     # If we don't find the config.py we use the following defaults
     logging.info("Configuration file not found, using defaults")
     app.config['FLAMENCO_MANAGER'] = 'localhost:7777'
     app.config['TMP_FOLDER'] = tempfile.gettempdir()
     app.config['PORT'] = 5000
     app.config['WORKER_STORAGE_DIR'] = 'flamenco-worker'
+    app.config['HOSTNAME'] = socket.gethostname()
+    app.config['BLENDER_PATH'] = '/usr/bin/blender'
+
 
 # Clean the temp folder from previous sessions
 tmp_folder = os.path.join(app.config['TMP_FOLDER'], app.config['WORKER_STORAGE_DIR'])

--- a/flamenco/worker/application/__init__.py
+++ b/flamenco/worker/application/__init__.py
@@ -24,10 +24,7 @@ try:
         FLAMENCO_MANAGER = config.Config.FLAMENCO_MANAGER,
         TMP_FOLDER = config.Config.TMP_FOLDER,
         PORT = config.Config.PORT,
-<<<<<<< HEAD
 	HOSTNAME = config.Config.HOSTNAME,
-=======
->>>>>>> 7666a26d9c8e1a4ca46c20eeebced269b7225952
         WORKER_STORAGE_DIR = config.Config.WORKER_STORAGE_DIR,
     )
 except ImportError:

--- a/flamenco/worker/application/__init__.py
+++ b/flamenco/worker/application/__init__.py
@@ -26,6 +26,8 @@ try:
         PORT = config.Config.PORT,
 	HOSTNAME = config.Config.HOSTNAME,
         WORKER_STORAGE_DIR = config.Config.WORKER_STORAGE_DIR,
+        BLENDER_PATH = config.Config.BLENDER_PATH,
+
     )
 except ImportError:
     # If we don't find the config.py we use the following defaults

--- a/flamenco/worker/application/__init__.py
+++ b/flamenco/worker/application/__init__.py
@@ -24,7 +24,10 @@ try:
         FLAMENCO_MANAGER = config.Config.FLAMENCO_MANAGER,
         TMP_FOLDER = config.Config.TMP_FOLDER,
         PORT = config.Config.PORT,
+<<<<<<< HEAD
 	HOSTNAME = config.Config.HOSTNAME,
+=======
+>>>>>>> 7666a26d9c8e1a4ca46c20eeebced269b7225952
         WORKER_STORAGE_DIR = config.Config.WORKER_STORAGE_DIR,
     )
 except ImportError:

--- a/flamenco/worker/application/__init__.py
+++ b/flamenco/worker/application/__init__.py
@@ -33,7 +33,7 @@ except ImportError:
     app.config['PORT'] = 5000
 
 # Clean the temp folder from previous sessions
-tmp_folder = os.path.join(app.config['TMP_FOLDER'], 'flamenco-worker')
+tmp_folder = os.path.join(app.config['TMP_FOLDER'], app.config['WORKER_STORAGE_DIR'])
 if not os.path.exists(tmp_folder):
     os.mkdir(tmp_folder)
 

--- a/flamenco/worker/application/__init__.py
+++ b/flamenco/worker/application/__init__.py
@@ -33,6 +33,7 @@ except ImportError:
     app.config['FLAMENCO_MANAGER'] = 'localhost:7777'
     app.config['TMP_FOLDER'] = tempfile.gettempdir()
     app.config['PORT'] = 5000
+    app.config['WORKER_STORAGE_DIR'] = 'flamenco-worker'
 
 # Clean the temp folder from previous sessions
 tmp_folder = os.path.join(app.config['TMP_FOLDER'], app.config['WORKER_STORAGE_DIR'])

--- a/flamenco/worker/application/config.py.example
+++ b/flamenco/worker/application/config.py.example
@@ -6,3 +6,5 @@ class Config(object):
     HOST = '0.0.0.0' # or localhost
     PORT = 5000
     TMP_FOLDER = tempfile.gettempdir()
+    HOSTNAME = socket.gethostname()
+    WORKER_STORAGE_DIR = ''.join(('flamenco-worker-', HOSTNAME))

--- a/flamenco/worker/application/config.py.example
+++ b/flamenco/worker/application/config.py.example
@@ -7,5 +7,6 @@ class Config(object):
     HOST = '0.0.0.0' # or localhost
     PORT = 5000
     TMP_FOLDER = tempfile.gettempdir()
+    BLENDER_PATH = '/opt/blender-2.75a-linux-glibc211-x86_64/blender'
     HOSTNAME = socket.gethostname()
     WORKER_STORAGE_DIR = ''.join(('flamenco-worker-', HOSTNAME))

--- a/flamenco/worker/application/config.py.example
+++ b/flamenco/worker/application/config.py.example
@@ -1,4 +1,5 @@
 import tempfile
+import socket
 
 class Config(object):
     DEBUG = False

--- a/flamenco/worker/application/controllers.py
+++ b/flamenco/worker/application/controllers.py
@@ -29,7 +29,6 @@ from application import clean_dir
 from requests.exceptions import ConnectionError
 
 MAC_ADDRESS = get_mac_address()  # the MAC address of the worker
-HOSTNAME = app.config['HOSTNAME']
 PLATFORM = platform.system()
 SYSTEM = PLATFORM + ' ' + platform.release()
 PROCESS = None
@@ -39,6 +38,8 @@ LOG = None
 TIME_INIT = None
 CONNECTIVITY = False
 FLAMENCO_MANAGER = app.config['FLAMENCO_MANAGER']
+HOSTNAME = app.config['HOSTNAME']
+#HOSTNAME = app.config['']
 
 if platform.system() is not 'Windows':
     from fcntl import fcntl, F_GETFL, F_SETFL

--- a/flamenco/worker/application/controllers.py
+++ b/flamenco/worker/application/controllers.py
@@ -39,7 +39,7 @@ LOG = None
 TIME_INIT = None
 CONNECTIVITY = False
 FLAMENCO_MANAGER = app.config['FLAMENCO_MANAGER']
-
+WORKER_STORAGE_DIR = ''.join(('flamenco-worker-', HOSTNAME))
 
 if platform.system() is not 'Windows':
     from fcntl import fcntl, F_GETFL, F_SETFL
@@ -217,11 +217,11 @@ def worker_loop():
             CONNECTIVITY = False
 
 
-        tmp_folder = os.path.join(app.config['TMP_FOLDER'], 'flamenco-worker')
+        tmp_folder = os.path.join(app.config['TMP_FOLDER'], WORKER_STORAGE_DIR)
         clean_dir(tmp_folder, task['job_id'])
 
         jobpath = os.path.join(app.config['TMP_FOLDER'],
-                               'flamenco-worker',
+                               WORKER_STORAGE_DIR,
                                str(task['job_id']))
         if not os.path.exists(jobpath):
             os.mkdir(jobpath)
@@ -407,7 +407,7 @@ def _parse_output(tmp_buffer, options):
 
     LOG = "{0}{1}".format(LOG, tmp_buffer)
     logpath = os.path.join(app.config['TMP_FOLDER'],
-                           'flamenco-worker',
+                           WORKER_STORAGE_DIR,
                            "{0}.log".format(task_id))
     f = open(logpath, 'a')
     f.write(tmp_buffer)
@@ -479,7 +479,7 @@ def run_blender_in_thread(options):
 
     render_command = json.loads(options['task_command'])
 
-    workerstorage = os.path.join(app.config['TMP_FOLDER'], 'flamenco-worker')
+    workerstorage = os.path.join(app.config['TMP_FOLDER'], WORKER_STORAGE_DIR)
     tmppath = os.path.join(
         workerstorage, str(options['job_id']))
     outpath = os.path.join(tmppath, 'output')
@@ -571,7 +571,7 @@ def run_blender_in_thread(options):
         time_cost = 0
         logging.error("time_init is None")
 
-    workerstorage = os.path.join(app.config['TMP_FOLDER'], 'flamenco-worker')
+    workerstorage = os.path.join(app.config['TMP_FOLDER'], WORKER_STORAGE_DIR)
     taskpath = os.path.join(
         workerstorage,
         str(options['job_id']),
@@ -741,7 +741,7 @@ def execute_task(task, files):
         'compiler_settings': task['compiler_settings'],
     }
 
-    workerstorage = os.path.join(app.config['TMP_FOLDER'], 'flamenco-worker')
+    workerstorage = os.path.join(app.config['TMP_FOLDER'], WORKER_STORAGE_DIR)
     taskpath = os.path.join(workerstorage, str(options['job_id']))
     zippath = os.path.join(taskpath, str(options['job_id']))
 

--- a/flamenco/worker/application/controllers.py
+++ b/flamenco/worker/application/controllers.py
@@ -39,7 +39,6 @@ LOG = None
 TIME_INIT = None
 CONNECTIVITY = False
 FLAMENCO_MANAGER = app.config['FLAMENCO_MANAGER']
-WORKER_STORAGE_DIR = ''.join(('flamenco-worker-', HOSTNAME))
 
 if platform.system() is not 'Windows':
     from fcntl import fcntl, F_GETFL, F_SETFL

--- a/flamenco/worker/application/controllers.py
+++ b/flamenco/worker/application/controllers.py
@@ -511,8 +511,8 @@ def run_blender_in_thread(options):
         render_command[cmd] = render_command[cmd].replace(
             "==outputpath==",outputpath)
         render_command[cmd] = render_command[cmd].replace(
-            "==command==",
-            compiler_settings['commands'][command_name][PLATFORM])
+            "==command==", app.config['BLENDER_PATH'])
+            #compiler_settings['commands'][command_name][PLATFORM])
 
     os.environ['WORKER_DEPENDPATH'] = dependpath
     os.environ['WORKER_OUTPUTPATH'] = outputpath

--- a/flamenco/worker/application/controllers.py
+++ b/flamenco/worker/application/controllers.py
@@ -29,7 +29,7 @@ from application import clean_dir
 from requests.exceptions import ConnectionError
 
 MAC_ADDRESS = get_mac_address()  # the MAC address of the worker
-HOSTNAME = socket.gethostname()  # the hostname of the worker
+HOSTNAME = app.config['HOSTNAME']
 PLATFORM = platform.system()
 SYSTEM = PLATFORM + ' ' + platform.release()
 PROCESS = None
@@ -216,11 +216,11 @@ def worker_loop():
             CONNECTIVITY = False
 
 
-        tmp_folder = os.path.join(app.config['TMP_FOLDER'], WORKER_STORAGE_DIR)
+        tmp_folder = os.path.join(app.config['TMP_FOLDER'], app.config['WORKER_STORAGE_DIR'])
         clean_dir(tmp_folder, task['job_id'])
 
         jobpath = os.path.join(app.config['TMP_FOLDER'],
-                               WORKER_STORAGE_DIR,
+                               app.config['WORKER_STORAGE_DIR'],
                                str(task['job_id']))
         if not os.path.exists(jobpath):
             os.mkdir(jobpath)
@@ -406,7 +406,7 @@ def _parse_output(tmp_buffer, options):
 
     LOG = "{0}{1}".format(LOG, tmp_buffer)
     logpath = os.path.join(app.config['TMP_FOLDER'],
-                           WORKER_STORAGE_DIR,
+                           app.config['WORKER_STORAGE_DIR'],
                            "{0}.log".format(task_id))
     f = open(logpath, 'a')
     f.write(tmp_buffer)
@@ -478,7 +478,7 @@ def run_blender_in_thread(options):
 
     render_command = json.loads(options['task_command'])
 
-    workerstorage = os.path.join(app.config['TMP_FOLDER'], WORKER_STORAGE_DIR)
+    workerstorage = os.path.join(app.config['TMP_FOLDER'], app.config['WORKER_STORAGE_DIR'])
     tmppath = os.path.join(
         workerstorage, str(options['job_id']))
     outpath = os.path.join(tmppath, 'output')
@@ -570,7 +570,7 @@ def run_blender_in_thread(options):
         time_cost = 0
         logging.error("time_init is None")
 
-    workerstorage = os.path.join(app.config['TMP_FOLDER'], WORKER_STORAGE_DIR)
+    workerstorage = os.path.join(app.config['TMP_FOLDER'], app.config['WORKER_STORAGE_DIR'])
     taskpath = os.path.join(
         workerstorage,
         str(options['job_id']),
@@ -740,7 +740,7 @@ def execute_task(task, files):
         'compiler_settings': task['compiler_settings'],
     }
 
-    workerstorage = os.path.join(app.config['TMP_FOLDER'], WORKER_STORAGE_DIR)
+    workerstorage = os.path.join(app.config['TMP_FOLDER'], app.config['WORKER_STORAGE_DIR'])
     taskpath = os.path.join(workerstorage, str(options['job_id']))
     zippath = os.path.join(taskpath, str(options['job_id']))
 

--- a/flamenco/worker/application/task_parsers/blender_render.py
+++ b/flamenco/worker/application/task_parsers/blender_render.py
@@ -57,7 +57,7 @@ class task_parser():
         if saved_file:
             file_name = "thumbnail_%s.png" % options['task_id']
             output_path = os.path.join(app.config['TMP_FOLDER'],
-                                       'flamenco-worker',
+                                       app.config['WORKER_STORAGE_DIR'],
                                        file_name)
             print('Saving {0} to {1}'.format(file_name, output_path))
             tmberror = False


### PR DESCRIPTION
It could be possible that the worker software being shared over NFS and each node needs to have separate storage folder. Removing the costant "flamenco-worker" as folder name permits some customization.